### PR TITLE
feat: DOT-421 Update dependencies to support JiraCloud.

### DIFF
--- a/jirachlog/ver.py
+++ b/jirachlog/ver.py
@@ -2,4 +2,4 @@
 # 1) we don't load dependencies by storing it in __init__.py
 # 2) we can import it in setup.py for the same reason
 # 3) we can import it into your module module
-__version__ = '1.3.1'
+__version__ = '1.4.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-jira==2.0.0
+jira==3.2.0
 pylint==2.3.1
 twine==1.13.0

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,6 @@ setup(name='jirachlog',
     scripts=['bin/jirachlog'],
     zip_safe=False,
     install_requires=[
-        'jira>=2.0.0'
+        'jira>=3.0.0'
     ],
 )


### PR DESCRIPTION
**Why is this needed**:

DR is moving it's onprem JIRA to JIRACloud.
And we think updating the dependencies in this binary will be our best option to continue using Changelogs as we are doing today.


Also taking this opportunity to fix minor issues reported by Sonarlint.
